### PR TITLE
No need for virtual ResetAndReleaseOperation

### DIFF
--- a/src/PooledValueTaskSource/FileReadingPooledValueTaskSource.cs
+++ b/src/PooledValueTaskSource/FileReadingPooledValueTaskSource.cs
@@ -217,7 +217,7 @@ namespace PooledValueTaskSource
             throw new InvalidOperationException("Multiple awaiters are not allowed");
         }
 
-        protected virtual string ResetAndReleaseOperation()
+        private string ResetAndReleaseOperation()
         {
             string result = this.result;
             this.token++;


### PR DESCRIPTION
As the IVTCS has no classes that are derived from it, `ResetAndReleaseOperation` can be just `private`